### PR TITLE
Switch local webserver for GitPod

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "license": "Apache-2.0",
   "devDependencies": {
+    "browser-sync": "^2.26.12",
     "http-server": "^0.12.3"
   },
   "scripts": {
-    "start": "http-server"
+    "start": "browser-sync --no-ui"
   }
 }


### PR DESCRIPTION
This change switched to the `browser-sync` server for GitPod containers.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>